### PR TITLE
Update license of Google Material Design Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Templates - [WTFPL](http://www.wtfpl.net/)
 
 Community Icons - [SIL Open Font License 1.1](http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web)
 
-Google Material Design Icons - [Attribution 4.0 International](https://github.com/google/material-design-icons/blob/master/LICENSE)
+Google Material Design Icons - [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE)
 
 ## Code of Conduct
 


### PR DESCRIPTION
They've changed their license already some time ago to Apache 2.0