### PR TITLE
Add getting start note about icons in Vue

### DIFF
--- a/site/getting-started.savvy
+++ b/site/getting-started.savvy
@@ -208,6 +208,10 @@ Learn more about custom icons in the [polymer documentation for v0.5](https://ww
 
 If you use React with the [Material-UI](http://www.material-ui.com/) component library, you can use a [third-party package](https://github.com/TeamWertarbyte/mdi-material-ui) that provides `SvgIcon` wrappers for every icon.
 
+## Vue
+
+If you are using [Vue.js](https://vuejs.org/ "Vue homepage"), you can find a collection of the SVG icons as single file components packaged as [vue-material-design-icons](https://www.npmjs.com/package/vue-material-design-icons "vue-material-design-icons on NPM").
+
 ## Cordova
 
 Due to a "bug" in Cordova you will need to manually edit the css file to remove the version query string. [Read More](https://github.com/Templarian/MaterialDesign/issues/760).


### PR DESCRIPTION
This patch adds a small note to the Getting Started guide about easily using the SVG icons in Vue. Fixes #2281 