### PR TITLE
Fix Vue section in getting-start

### DIFF
--- a/site/getting-started.savvy
+++ b/site/getting-started.savvy
@@ -210,7 +210,7 @@ If you use React with the [Material-UI](http://www.material-ui.com/) component l
 
 ## Vue
 
-If you are using [Vue.js](https://vuejs.org/ "Vue homepage"), you can find a collection of the SVG icons as single file components packaged as [vue-material-design-icons](https://www.npmjs.com/package/vue-material-design-icons "vue-material-design-icons on NPM").
+If you are using [Vue.js](https://vuejs.org/), you can find a collection of the SVG icons as single file components packaged as [vue-material-design-icons](https://www.npmjs.com/package/vue-material-design-icons).
 
 ## Cordova
 


### PR DESCRIPTION
Despite looking a lot like Markdown, this doesn't appear to be processed the same way, so the quoted text was being parsed as a URL, not a title. This patch fixes it to just show the URL.