### PR TITLE
correction on flip-* classes

### DIFF
--- a/site/getting-started.savvy
+++ b/site/getting-started.savvy
@@ -94,11 +94,11 @@ Use either `.mdi-light` or `.mdi-dark` to set the color of the icon to the defau
 ```
 
 #### Flip
-Icons can be flipped horizontally and/or vertically using the classes `.mdi-flip-horizontal` and `.mdi-flip-vertical`.
+Icons can be flipped horizontally and/or vertically using the classes `.mdi-flip-h` and `.mdi-flip-v`.
 
 ```html Flip Example
-<a class="mdi mdi-home mdi-flip-horizontal" href="/">Home</a> 
-<a class="mdi mdi-home mdi-flip-vertical" href="/">Home</a> 
+<a class="mdi mdi-home mdi-flip-h" href="/">Home</a> 
+<a class="mdi mdi-home mdi-flip-v" href="/">Home</a> 
 ```
 
 #### Rotate


### PR DESCRIPTION
Hi,

First, thank a lot for your great work!

While integrating MDI to my project, I found out what could be a typo in the "Getting Started" page.

According to the .scss, the correct classes are `.mdi-flip-h` and `.mdi-flip-v`, not `.mdi-flip-horizontal` and `.mdi-flip-vertical`:
```
.#{$mdi-css-prefix}-flip-h:before {
    -webkit-transform: scaleX(-1);
    transform: scaleX(-1);
    filter: FlipH;
    -ms-filter: "FlipH";
}
.#{$mdi-css-prefix}-flip-v:before {
    -webkit-transform: scaleY(-1);
    transform: scaleY(-1);
    filter: FlipV;
    -ms-filter: "FlipV";
}
```

Hope this will help.

Cheers