### PR TITLE
Update angular material2 version to latest

### DIFF
--- a/site/getting-started.savvy
+++ b/site/getting-started.savvy
@@ -174,29 +174,35 @@ Android uses the Vector Drawable format that is similar to SVG. Right click any 
 
 Windows uses the vector XAML format. Right click any icon on the site and click the "View XAML" item in the context menu.
 
-## Angular 2.x/4.x @download(Download for Angular Material v2 'mdi.svg', /api/download/angularmaterial/38EF63D0-4744-11E4-B3CF-842B2B6CFE1B)
+## Angular 2.x/4.x @download(Download for Angular Material 'mdi.svg', /api/download/angularmaterial/38EF63D0-4744-11E4-B3CF-842B2B6CFE1B)
 
-The `mdi.svg` contains all the icons provided on the site. Use inline with [MdIconRegistry](https://material.angular.io/components/icon/api).
+The `mdi.svg` contains all the icons provided on the site. Use inline with [MatIconRegistry](https://material.angular.io/components/icon/api).
+The following assumes that you're using the latest version of `@angular/material` (`2.0.0-beta.12`) and you already have the basic knowledge of Angular Material.
 Place the SVG file under your `assets` folder. Please ensure that this file is publicly accessible.
-In your app's module file (typically `app.module.ts`), add the following lines:
+In your app's module file (typically `app.module.ts`), import `MatIconModule` and `MatIconRegistry` from `@angular/material`:
 
 ```typescript App module
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
-import { MdIconRegistry, MdIconModule } from '@angular/material';
+import { MatIconRegistry, MatIconModule } from '@angular/material';
 import { DomSanitizer } from '@angular/platform-browser';
+import { HttpModule } from '@angular/http';
+
 ...
 @NgModule([
     imports: [
         BrowserModule,
         BrowserAnimationsModule,
+        HttpModule,
         // Your other modules
-        // Take note that you have to import MdIconModule into your app
-        MdIconModule
+        // Take note that you have to import MatIconModule into your app
+        MatIconModule
     ]
 ])
 export class AppModule {
-    constructor(mdIconRegistry: MdIconRegistry, domSanitizer: DomSanitizer){
-        mdIconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl('./src/assets/mdi.svg')); // Or whatever path you placed mdi.svg at
+    constructor(matIconRegistry: MatIconRegistry, domSanitizer: DomSanitizer){
+        matIconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl('./assets/mdi.svg')); // Or whatever path you placed mdi.svg at
     }
 }
 ```
@@ -218,20 +224,22 @@ If you're using Angular CLI, make sure to include `assets` folder under `.angula
 Usage:
 
 ```html Example Usage
-<md-icon svgIcon="android"></md-icon>
-<button md-icon-button>
-    <md-icon svgIcon="android"></md-icon>
+<!-- Icon by itself -->
+<mat-icon svgIcon="android"></mat-icon>
+<!-- Icon button -->
+<button mat-icon-button>
+    <mat-icon svgIcon="android"></mat-icon>
 </button>
 <!-- You can also combine an icon and text together -->
-<button md-button>
-    <md-icon svgIcon="code-tags"></md-icon>
+<button mat-button>
+    <mat-icon svgIcon="code-tags"></mat-icon>
     View source
 </button>
 ```
 
-[Demo](http://plnkr.co/edit/Qtn1XeKPUdQtY5hntFIF?p=preview)
+[Demo](https://stackblitz.com/edit/mdi-material-example)
 
-For more information on icons, refer [here](https://material.angular.io/components/icon/overview).
+For more information on icons, refer to the [icon docs](https://material.angular.io/components/icon/overview).
 
 ## Angular JS @download(Download for AngularJS Material 'mdi.svg', /api/download/angularmaterial/38EF63D0-4744-11E4-B3CF-842B2B6CFE1B)
 

--- a/site/getting-started.savvy
+++ b/site/getting-started.savvy
@@ -188,22 +188,27 @@ import { NgModule } from '@angular/core';
 import { MatIconRegistry, MatIconModule } from '@angular/material';
 import { DomSanitizer } from '@angular/platform-browser';
 import { HttpModule } from '@angular/http';
+/*
+From the latest master, HttpClientModule is required instead
+import { HttpClientModule } from '@angular/common/http';
+*/
 
 ...
-@NgModule([
-    imports: [
-        BrowserModule,
-        BrowserAnimationsModule,
-        HttpModule,
-        // Your other modules
-        // Take note that you have to import MatIconModule into your app
-        MatIconModule
-    ]
-])
+@NgModule({
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    HttpModule,
+    // From the latest master, HttpClientModule is required instead
+    // Your other modules
+    // Take note that you have to import MatIconModule into your app
+    MatIconModule
+  ]
+})
 export class AppModule {
-    constructor(matIconRegistry: MatIconRegistry, domSanitizer: DomSanitizer){
-        matIconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl('./assets/mdi.svg')); // Or whatever path you placed mdi.svg at
-    }
+  constructor(matIconRegistry: MatIconRegistry, domSanitizer: DomSanitizer){
+    matIconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl('./assets/mdi.svg')); // Or whatever path you placed mdi.svg at
+  }
 }
 ```
 
@@ -211,14 +216,13 @@ If you're using Angular CLI, make sure to include `assets` folder under `.angula
 
 ```json Angular CLI file
 {
-     "apps": [
-         {
-              ...
-              "assets": [
-                  "assets"
-              ]
-         }
-     ]
+   "apps": [
+     {
+       "assets": [
+         "assets"
+       ]
+     }
+   ]
 }
 ```
 Usage:
@@ -228,13 +232,24 @@ Usage:
 <mat-icon svgIcon="android"></mat-icon>
 <!-- Icon button -->
 <button mat-icon-button>
-    <mat-icon svgIcon="android"></mat-icon>
+  <mat-icon svgIcon="android"></mat-icon>
 </button>
 <!-- You can also combine an icon and text together -->
 <button mat-button>
-    <mat-icon svgIcon="code-tags"></mat-icon>
-    View source
+  <mat-icon svgIcon="code-tags"></mat-icon>
+  View source
 </button>
+```
+
+Please also add the following class to your styles (`styles.css`) to solve the problem where an icon isn't aligned properly when used in a menu item:
+
+```css styles.css
+button.mat-menu-item {
+  line-height: 24px !important;
+}
+a.mat-menu-item > mat-icon {
+  margin-bottom: 14px;
+}
 ```
 
 [Demo](https://stackblitz.com/edit/mdi-material-example)
@@ -258,7 +273,7 @@ Usage:
 ```html Example Usage
 <md-icon md-svg-icon="android"></md-icon>
 <md-button aria-label="Android" class="md-icon-button">
-    <md-icon md-svg-icon="android"></md-icon>
+  <md-icon md-svg-icon="android"></md-icon>
 </md-button>
 ```
 


### PR DESCRIPTION
- Add HTML comments to example usage
- Update section to new version (`2.0.0-beta.12`) which removes the now removed `Md` prefix
- Change demo to use Stackblitz
- Rephrase some words, change grammar
- Add missing module imports
- Add notice to import `HttpClientModule` if the user's on `master`
- Change indent to two spaces
- Add fix on misaligned icons if used in a menu