### PR TITLE
Added new wifi icons

### DIFF
--- a/svg/wifi-alert.svg
+++ b/svg/wifi-alert.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg361"
+   sodipodi:docname="wifi-alert.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata367">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs365" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1528"
+     inkscape:window-height="836"
+     id="namedview363"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="6.6685551"
+     inkscape:cy="10.805456"
+     inkscape:window-x="1992"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg361" />
+  <path
+     d="M 12 3 C 7.95 3 4.2092188 4.3396094 1.1992188 6.5996094 L 3 9 C 5.5 7.12 8.62 6 12 6 C 13.470195 6 14.88633 6.2230103 16.228516 6.6171875 L 16.228516 6.6035156 L 22.796875 6.6035156 L 22.800781 6.5996094 C 19.790781 4.3396094 16.05 3 12 3 z M 12 9 C 9.3 9 6.8107812 9.8903906 4.8007812 11.400391 L 6.5996094 13.800781 C 8.0996094 12.670781 9.97 12 12 12 C 13.530672 12 14.969809 12.382852 16.228516 13.054688 L 16.228516 9.7753906 C 14.911874 9.2787501 13.489898 9 12 9 z M 12 15 C 10.65 15 9.4003906 15.449219 8.4003906 16.199219 L 12 21 L 15.599609 16.199219 C 14.599609 15.449219 13.35 15 12 15 z "
+     id="path359" />
+  <path
+     id="path4117"
+     d="m 18.018836,16.521097 h 3 V 8.1210964 h -3 m 0,14.0000006 h 3 v -2.8 h -3 z"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccc"
+     style="stroke-width:1.44913757" />
+</svg>

--- a/svg/wifi-check.svg
+++ b/svg/wifi-check.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4300"
+   sodipodi:docname="wifi-check.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata4306">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4304" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1528"
+     inkscape:window-height="836"
+     id="namedview4302"
+     showgrid="false"
+     inkscape:zoom="13.906433"
+     inkscape:cx="3.5902861"
+     inkscape:cy="18.183189"
+     inkscape:window-x="1992"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4300" />
+  <path
+     d="M 12 3 C 7.95 3 4.2092188 4.3396094 1.1992188 6.5996094 L 3 9 C 5.5 7.12 8.62 6 12 6 C 15.38 6 18.5 7.12 21 9 L 22.800781 6.5996094 C 19.790781 4.3396094 16.05 3 12 3 z M 12 9 C 9.3 9 6.8107812 9.8903902 4.8007812 11.400391 L 6.5996094 13.800781 C 8.0996094 12.670781 9.97 12 12 12 C 13.926591 12 15.705179 12.609205 17.164062 13.636719 L 18.605469 12.193359 L 19.199219 11.400391 C 17.189219 9.8903902 14.7 9 12 9 z M 12 15 C 10.65 15 9.4003906 15.449219 8.4003906 16.199219 L 12 21 L 13.427734 19.095703 L 10.777344 16.445312 L 11.359375 15.865234 L 12.207031 15.017578 C 12.137161 15.015149 12.070436 15 12 15 z "
+     id="path4298" />
+  <path
+     id="path4626-7-5"
+     d="m 16.154224,19.690311 -3.282241,-3.282241 1.495771,-1.495772 1.78647,1.791755 5.221988,-5.227273 1.495771,1.495772 z"
+     inkscape:connector-curvature="0"
+     style="stroke-width:0.52854127" />
+</svg>

--- a/svg/wifi-connected.svg
+++ b/svg/wifi-connected.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4463"
+   sodipodi:docname="wifi-connected.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata4469">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4467" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1528"
+     inkscape:window-height="836"
+     id="namedview4465"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="11.105987"
+     inkscape:cy="9.8007886"
+     inkscape:window-x="1992"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4463" />
+  <path
+     d="M 12 3 C 7.95 3 4.2092188 4.3396094 1.1992188 6.5996094 L 3 9 C 5.5 7.12 8.62 6 12 6 C 15.38 6 18.5 7.12 21 9 L 22.800781 6.5996094 C 19.790781 4.3396094 16.05 3 12 3 z M 12 9 C 9.3 9 6.8107812 9.8903906 4.8007812 11.400391 L 6.5996094 13.800781 C 8.0996094 12.670781 9.97 12 12 12 C 12.590491 12 13.16441 12.063663 13.722656 12.171875 L 16 9.6875 C 14.748031 9.24455 13.403342 9 12 9 z M 12 15 C 10.65 15 9.4003906 15.449219 8.4003906 16.199219 L 12 21 L 14.441406 17.744141 L 14.441406 15.539062 C 13.693175 15.203881 12.872149 15 12 15 z "
+     id="path4461" />
+  <path
+     id="path4535-6"
+     d="m 19.839925,13.764595 h -1.666667 v 3.333334 h -2.777777 v -3.333334 h -1.666667 l 3.055556,-3.333333 3.055555,3.333333 m 0.833333,7.777778 3.055556,-3.333333 H 22.062147 V 14.875706 H 19.28437 v 3.333334 h -1.666667 z"
+     inkscape:connector-curvature="0"
+     style="stroke-width:0.55555558" />
+</svg>

--- a/svg/wifi-lock.svg
+++ b/svg/wifi-lock.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg5022"
+   sodipodi:docname="wifi.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata5028">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5026" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1528"
+     inkscape:window-height="836"
+     id="namedview5024"
+     showgrid="false"
+     inkscape:zoom="6.9532167"
+     inkscape:cx="-22.002725"
+     inkscape:cy="4.7032091"
+     inkscape:window-x="1992"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5022" />
+  <path
+     d="M 12,3 C 7.95,3 4.2092188,4.3396094 1.1992188,6.5996094 L 3,9 c 2.5,-1.88 5.62,-3 9,-3 3.38,0 6.5,1.12 9,3 L 22.800781,6.5996094 C 19.790781,4.3396094 16.05,3 12,3 Z m 0,6 C 9.3,9 6.8107812,9.8903902 4.8007812,11.400391 l 1.7988282,2.40039 C 8.0996094,12.670781 9.97,12 12,12 c 0.533792,0 1.054652,0.04984 1.5625,0.138672 0.54852,-1.249835 1.788748,-2.124708 3.238281,-2.136719 C 15.32945,9.3582514 13.70764,9 12,9 Z m -0.183594,6.015625 c -1.278372,0.03934 -2.4622844,0.468296 -3.4160154,1.183594 l 3.4160154,4.55664 z"
+     id="path5020"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sccsccssccsccscccc" />
+  <path
+     d="m 16.948773,11.558429 c -1.380712,0 -2.5,1.119288 -2.5,2.5 v 0.5 c -0.552285,0 -1,0.447715 -1,1 v 4 c 0,0.552284 0.447715,1 1,1 h 5 c 0.552285,0 1,-0.447716 1,-1 v -4 c 0,-0.552285 -0.447715,-1 -1,-1 v -0.5 c 0,-1.380712 -1.119288,-2.5 -2.5,-2.5 z m 0,0.800781 c 0.94,0 1.701172,0.759219 1.701172,1.699219 v 0.5 h -3.400391 v -0.5 c 0,-0.94 0.759219,-1.699219 1.699219,-1.699219 z"
+     id="path5085"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/svg/wifi-sync.svg
+++ b/svg/wifi-sync.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4727"
+   sodipodi:docname="wifi-sync.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata4733">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4731" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1528"
+     inkscape:window-height="836"
+     id="namedview4729"
+     showgrid="false"
+     inkscape:zoom="13.906433"
+     inkscape:cx="14.250183"
+     inkscape:cy="10.190139"
+     inkscape:window-x="1992"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4727" />
+  <path
+     d="M 12,3 C 7.95,3 4.2092188,4.3396094 1.1992188,6.5996094 L 3,9 c 2.5,-1.88 5.62,-3 9,-3 3.38,0 6.5,1.12 9,3 L 22.800781,6.5996094 C 19.790781,4.3396094 16.05,3 12,3 Z m 0,6 C 9.3,9 6.8107812,9.8903902 4.8007812,11.400391 l 1.7988282,2.40039 C 8.0996094,12.670781 9.97,12 12,12 c 0.603409,0 1.188499,0.06997 1.757812,0.183594 L 16.179688,9.7617188 C 14.877448,9.2738464 13.472333,9 12,9 Z m -0.152344,6.011719 c -1.290612,0.03299 -2.4856331,0.466276 -3.4472654,1.1875 L 12,21 12.779297,19.960938 c -0.775102,-0.987922 -1.190544,-2.151977 -1.193359,-3.34375 0.0024,-0.542874 0.09043,-1.08296 0.261718,-1.605469 z"
+     id="path4725"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sccsccssccsccscccccc" />
+  <path
+     id="path4796-3"
+     d="m 16.702416,19.437558 a 3,3 0 0 1 -3,-3 c 0,-0.5 0.125,-0.985 0.35,-1.4 l -0.73,-0.73 c -0.39,0.615 -0.62,1.345 -0.62,2.13 a 4,4 0 0 0 4,4 v 1.5 l 2,-2 -2,-2 m 0,-5.5 v -1.5 l -2,2 2,2 v -1.5 a 3,3 0 0 1 3,3 c 0,0.5 -0.125,0.985 -0.35,1.4 l 0.73,0.73 c 0.39,-0.615 0.62,-1.345 0.62,-2.13 a 4,4 0 0 0 -4,-4 z"
+     inkscape:connector-curvature="0"
+     style="stroke-width:0.5" />
+</svg>


### PR DESCRIPTION
I added new wifi icons with status.  Issue number #5575 
1. wifi-sync
![wifi-sync](https://user-images.githubusercontent.com/71327582/96371374-1d98bd00-117f-11eb-81bd-6e691b98a8f4.png)
2. wifi-connected
![wifi-connected](https://user-images.githubusercontent.com/71327582/96371387-28535200-117f-11eb-90ca-33cc90ede49d.png)
3. wifi-check
![wifi-check](https://user-images.githubusercontent.com/71327582/96371402-373a0480-117f-11eb-8e31-d71ab8ac7ee6.png)
4. wifi-alert
![wifi-alert](https://user-images.githubusercontent.com/71327582/96371453-5e90d180-117f-11eb-93f2-507aa633ec71.png)
5. wifi-lock
![wifi-lock](https://user-images.githubusercontent.com/71327582/96371449-5a64b400-117f-11eb-8beb-e8a580053e6e.png)

Let me know if any modifications are required.