### PR TITLE
Change link to all issues in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/1_icon_request.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: "Before submitting a new icon request, please confirm the following:"
       options:
-        - label: I have [searched all issues](https://github.com/Templarian/MaterialDesign/issues) to make sure there isn't a request for this icon.
+        - label: I have [searched all issues](https://github.com/Templarian/MaterialDesign/issues?q=is%3Aissue) to make sure there isn't a request for this icon.
           required: true
         - label: I have [searched the current library](https://materialdesignicons.com/) to make sure the icon doesn't already exist.
           required: true

--- a/.github/ISSUE_TEMPLATE/2_contribution.yml
+++ b/.github/ISSUE_TEMPLATE/2_contribution.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: "Before submitting a new icon contribution, please confirm the following:"
       options:
-        - label: I have [searched all issues](https://github.com/Templarian/MaterialDesign/issues) to make sure there isn't a request for this icon.
+        - label: I have [searched all issues](https://github.com/Templarian/MaterialDesign/issues?q=is%3Aissue) to make sure there isn't a request for this icon.
           required: true
         - label: I have [searched the current library](https://materialdesignicons.com/) to make sure the icon doesn't already exist.
           required: true

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        *Make sure you [searched open issues](https://github.com/Templarian/MaterialDesign/issues) before submitting your bug report!*
+        *Make sure you [searched all issues](https://github.com/Templarian/MaterialDesign/issues?q=is%3Aissue) before submitting your bug report!*
 
         ---
 

--- a/.github/ISSUE_TEMPLATE/4_alias.yml
+++ b/.github/ISSUE_TEMPLATE/4_alias.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        *Make sure you [searched open issues](https://github.com/Templarian/MaterialDesign/issues) before submitting your alias request!*
+        *Make sure you [searched all issues](https://github.com/Templarian/MaterialDesign/issues?q=is%3Aissue) before submitting your alias request!*
 
         ---
 

--- a/.github/ISSUE_TEMPLATE/5_tag.yml
+++ b/.github/ISSUE_TEMPLATE/5_tag.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        *Make sure you [searched open issues](https://github.com/Templarian/MaterialDesign/issues) before submitting your tag request!*
+        *Make sure you [searched all issues](https://github.com/Templarian/MaterialDesign/issues?q=is%3Aissue) before submitting your tag request!*
 
         ---
 


### PR DESCRIPTION
Lead users to all issues for searching, not just open issues. Duplicate and rejected requests/bug reports are closed issues, so in order to avoid duplicates (see https://github.com/Templarian/MaterialDesign/issues/6232#issuecomment-939969806 for instance), users should search all existing issues by default.